### PR TITLE
Fix broken Skip Ratchet link

### DIFF
--- a/spec/skip-ratchet.md
+++ b/spec/skip-ratchet.md
@@ -1,6 +1,6 @@
 # Skip Ratchet
 
-The skip ratchet is described in this paper: https://github.com/fission-suite/skip-ratchet-paper/blob/main/spiral-ratchet.pdf
+The skip ratchet is described in this paper: https://eprint.iacr.org/2022/1078
 
 ## Encoding
 


### PR DESCRIPTION
The skip ratchet link is broken, I think since we changed the org name. I updated it to the e-print link.