### PR TITLE
Private File Sharding

### DIFF
--- a/.github/workflows/words-to-ignore.txt
+++ b/.github/workflows/words-to-ignore.txt
@@ -77,6 +77,7 @@ low-endian
 big-endian
 codec
 backlink like link
+prepend like append
 
 # rationale
 Combinatoric

--- a/.github/workflows/words-to-ignore.txt
+++ b/.github/workflows/words-to-ignore.txt
@@ -76,6 +76,7 @@ userland
 low-endian
 big-endian
 codec
+backlink like link
 
 # rationale
 Combinatoric

--- a/.github/workflows/words-to-ignore.txt
+++ b/.github/workflows/words-to-ignore.txt
@@ -75,6 +75,7 @@ superset like set
 userland
 low-endian
 big-endian
+codec
 
 # rationale
 Combinatoric

--- a/.github/workflows/words-to-ignore.txt
+++ b/.github/workflows/words-to-ignore.txt
@@ -11,6 +11,7 @@ Bluesky
 
 # Spec
 cleartext
+plaintext
 Cleartext
 sharding
 multimap
@@ -72,6 +73,8 @@ idempotence like omnipotence
 subdirectory like directory
 superset like set
 userland
+low-endian
+big-endian
 
 # rationale
 Combinatoric

--- a/.github/workflows/words-to-ignore.txt
+++ b/.github/workflows/words-to-ignore.txt
@@ -78,6 +78,7 @@ big-endian
 codec
 backlink like link
 prepend like append
+preimage like image
 
 # rationale
 Combinatoric

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ WNFS is content-addressed and thus extremely portable. It may be stored on the e
 
 ## Suite of Specifications
 
-The WNFS spec is a suite of specifications consisting of public WNFS, private WNFS and its parts. Some of these specifications use common notation described in [notation.md](/notation.md).
+The WNFS spec is a suite of specifications consisting of public WNFS, private WNFS and its parts. Some of these specifications use common notation described in [notation.md](/spec/notation.md).
 
 The specifications are:
 - [Public WNFS](/spec/public-wnfs.md)

--- a/spec/private-wnfs.md
+++ b/spec/private-wnfs.md
@@ -161,6 +161,8 @@ The block count for externalized content MUST reference the number of blocks the
 
 Each block MUST be a $2^{18} = 262144$ byte ciphertext, where the first 12 bytes are the initialization vector for encryption, so each block MUST encode exactly 262,132 plaintext bytes, except for the last block with index equal to `blockCount - 1`, which MAY be smaller.
 
+The externalized content's `key` MUST be re-generated randomly every time the file content changes. It MAY stay the same across private file header revisions if only file metadata changes.
+
 ### 3.2.1 Private Directory
 
 A private directory MUST contain links to zero or more further nodes. Private directories MAY include userland metadata.

--- a/spec/private-wnfs.md
+++ b/spec/private-wnfs.md
@@ -74,7 +74,11 @@ A space optimization delaying the creation of additional layers until 3 collisio
 
 #### 2.1.1.3 `Entry`
 
-A leaf node, containing the expanded label as well as a value. As the private forest for WNFS, this MUST contain a namefilter as label and a set of CIDs of ciphertexts of conflicting writes as the value.
+An `Entry` node MUST consist of:
+* The expanded label (HAMT hash preimage)
+* The value for this label
+
+If the HAMT is used as the `PrivateForest` for WNFS, then the values stored SHOULD be ciphertexts representing conflicting file system writes to that same path and revision.
 
 ## 2.2 Ciphertext Files
 

--- a/spec/private-wnfs.md
+++ b/spec/private-wnfs.md
@@ -163,7 +163,7 @@ The block count for externalized content MUST reference the number of blocks the
 
 The externalized content's `key` MUST be regenerated randomly whenever the file content changes. If the content stays the same across metadata changes, the content key MAY remain the same across those revisions
 
-The namefilters to be used as labels for the ciphertexts in the HAMT are computed as defined in [Algorithm 4.4: Sharded File Content Access](#44-sharded-file-content-access).
+NB: label namefilters MUST be computed per [Algorithm 4.4](#44-sharded-file-content-access)
 
 Each multi-value in the HAMT MUST have exactly one CID. That CID refers to a ciphertext block. Each block MUST be a $2^{18} = 262144$ byte ciphertext, where the first 12 bytes are the initialization vector for encryption, so each block MUST encode exactly 262,132 plaintext bytes, except for the last block with index equal to `blockCount - 1`, which MAY be smaller, but MUST NOT encode an empty plaintext.
 

--- a/spec/private-wnfs.md
+++ b/spec/private-wnfs.md
@@ -146,7 +146,7 @@ type ExternalContent = {
 
 ### 3.1.1 Node Headers
 
-Node headers MUST be encrypted with the key derived from the node's skip ratchet: the "content key". Headers MUST NOT grant access to other versions of the associated node. Node headers are in kernel space and MUST NOT be user writable. Refer to the section [Pointers & Keys](#323-pointers--keys) for more detail.
+Node headers MUST be encrypted with the key derived from the node's skip ratchet: the "content key". Headers MUST NOT grant access to other versions of the associated node. Node headers are in kernel space and MUST NOT be user writable. Refer to [Pointers & Keys](#323-pointers--keys) for more detail.
 
 ### 3.1.2 Node Metadata
 

--- a/spec/private-wnfs.md
+++ b/spec/private-wnfs.md
@@ -37,7 +37,7 @@ Ciphertext blocks MUST be stored as the leaves of the HAMT that encodes a [multi
 
 ### 2.1.1 Data Types
 
-The multimap container MUST be represented as a CBOR-encoded Merkle HAMT. The values MUST be a set of raw-codec CIDs.
+The multimap container MUST be represented as a CBOR-encoded Merkle HAMT. The values MUST be a set of `raw` codec CIDs.
 
 All values in the Merkle HAMT MUST be sorted in binary ascending order by CID and MUST NOT contain duplicates.
 

--- a/spec/private-wnfs.md
+++ b/spec/private-wnfs.md
@@ -292,7 +292,7 @@ If this mode is seeking, the `directory.entries[segmentName].revisionKey` needs 
 
 ##### 4.3.2.1.1 Example
 
-To illustrate this mode, consider the following diagram. An agent may only have access to some nodes, but not their parent. The agent is able to create new revisions of files and directories, and link that back to the previous version. Some number of revisions may accrue before this can be fully rooted again. Attachment occurs when a reader with enough rights to perform the attachment inspects the file system and discovers that they can attach this file to its parents.
+Consider the following diagram. An agent may only have access to some nodes, but not their parent. The agent is able to create new revisions of files and directories, and link that back to the previous version. Some number of revisions may accrue before this can be fully rooted again. Attachment occurs when a reader with enough rights to perform the attachment inspects the file system and discovers that they can attach this file to its parents.
 
 ![](./diagrams/attach.svg)
 

--- a/spec/private-wnfs.md
+++ b/spec/private-wnfs.md
@@ -234,9 +234,9 @@ All algorithms MUST have access to a `PrivateForest` in their context.
 
 ## 4.1 Namefilter Hash Resolution
 
-`resolveHashedKey: Hash<Namefilter> -> (Namefilter, Encrypted<PrivateNodeHeader>, Array<Encrypted<PrivateNode>>)`
+`resolveHashedKey: Hash<Namefilter> -> (Namefilter, Array<Encrypted<PrivateNode>>)`
 
-The private file system is a pointer machine, where pointers MUST be hashes of namefilters. To resolve a namefilter hash, look up the hash in the HAMT. The resulting key-value pair MUST contain the full "expanded" namefilter, the private node header, and a list of at least one private node.
+The private file system is a pointer machine, where pointers MUST be hashes of namefilters. To resolve a namefilter hash, look up the hash in the HAMT. The resulting key-value pair MUST contain the full "expanded" namefilter and a list of at least one private node.
 
 Looking up a namefilter hash in the HAMT works by splitting a hash into its nibbles. For example: a hash `0xf199a877d0...` MUST be split into the nibbles `0xf`, `0x1`, `0x9`, etc.
 

--- a/spec/private-wnfs.md
+++ b/spec/private-wnfs.md
@@ -161,7 +161,7 @@ Since external content blocks are separate from the header, they MUST have a uni
 
 The block count for externalized content MUST reference the number of blocks the externalized content was split into.
 
-The externalized content's `key` MUST be re-generated randomly every time the file content changes. It MAY stay the same across private file header revisions if only file metadata changes.
+The externalized content's `key` MUST be regenerated randomly whenever the file content changes. If the content stays the same across metadata changes, the content key MAY remain the same across those revisions
 
 The namefilters to be used as labels for the ciphertexts in the HAMT are computed as defined in [Algorithm 4.4: Sharded File Content Access](#44-sharded-file-content-access).
 

--- a/spec/private-wnfs.md
+++ b/spec/private-wnfs.md
@@ -143,7 +143,7 @@ type ExternalContent = {
 
 ### 3.2.1 Node Headers
 
-Node headers MUST be encrypted with the key derived from the node's skip ratchet: the "content key". Headers MUST NOT grant access to other versions of the associated node. Node headers are in kernel space and MUST NOT be user writable. Refer to [§3.2.3 Pointers & Keys](#323-pointers--keys) for more detail.
+Node headers MUST be encrypted with the key derived from the node's skip ratchet: the "content key". Headers MUST NOT grant access to other versions of the associated node. Node headers are in kernel space and MUST NOT be user writable. Refer to the section [Pointers & Keys](#323-pointers--keys) for more detail.
 
 ### 3.2.2 Node Metadata
 
@@ -157,13 +157,13 @@ Private file content has two variants: inlined or externalized. Externalized con
 
 #### 3.2.1.1 Externalized Content
 
-Since external content blocks are separate from the header, they MUST have a unique namefilter derived from a random key (to avoid forcing lookups to go through the header). If the key were derived from the header's key, then the file would be re-encrypted e.g. every time the metadata changed. See [the relevant algorithm](#44-shared-file-content-access) for more detail.
+Since external content blocks are separate from the header, they MUST have a unique namefilter derived from a random key (to avoid forcing lookups to go through the header). If the key were derived from the header's key, then the file would be re-encrypted e.g. every time the metadata changed. See [sharded file content access algorithm](#44-shared-file-content-access) for more detail.
 
 The block count for externalized content MUST reference the number of blocks the externalized content was split into.
 
 The externalized content's `key` MUST be regenerated randomly whenever the file content changes. If the content stays the same across metadata changes, the content key MAY remain the same across those revisions
 
-NB: label namefilters MUST be computed per [Algorithm 4.4](#44-sharded-file-content-access)
+NB: Label namefilters MUST be computed as described in the algorithm for [sharded file content access](#44-sharded-file-content-access).
 
 Each multi-value in the HAMT MUST have exactly one CID. That CID refers to a ciphertext block. Each block MUST be a $2^{18} = 262144$ byte ciphertext, where the first 12 bytes are the initialization vector for encryption, so each block MUST encode exactly 262,132 plaintext bytes, except for the last block with index equal to `blockCount - 1`, which MAY be smaller, but MUST NOT encode an empty plaintext.
 
@@ -171,7 +171,7 @@ Each multi-value in the HAMT MUST have exactly one CID. That CID refers to a cip
 
 A private directory MUST contain links to zero or more further nodes. Private directories MAY include userland metadata.
 
-See [§3.2.4 Read Hierarchy](#324-read-hierarchy) for more information about the link structure.
+See the section for [Read Hierarchy](#324-read-hierarchy) for more information about the link structure.
 
 ### 3.2.3 Pointers & Keys
 

--- a/spec/private-wnfs.md
+++ b/spec/private-wnfs.md
@@ -37,7 +37,7 @@ Ciphertext blocks MUST be stored as the leaves of the HAMT that encodes a [multi
 
 ### 2.1.1 Data Types
 
-The multimap container MUST be represented as a CBOR-encoded Merkle HAMT. The values MUST be a set of `raw` codec CIDs.
+The multimap container MUST be represented as a CBOR-encoded Merkle HAMT. The values MUST be a set of [`raw` codec](https://github.com/multiformats/multicodec/blob/master/table.csv#L40) CIDs.
 
 All values in the Merkle HAMT MUST be sorted in binary ascending order by CID and MUST NOT contain duplicates.
 

--- a/spec/private-wnfs.md
+++ b/spec/private-wnfs.md
@@ -184,7 +184,7 @@ The externalized content's `key` MUST be regenerated randomly whenever the file 
 
 NB: Label namefilters MUST be computed as described in the algorithm for [sharded file content access](#44-sharded-file-content-access).
 
-Entries in the private forest corresponding to externalized content blocks MUST have exactly one CID as their multi-value. This CID MUST refer to a ciphertext with exactly `12 + blockSize` bytes, except for the last block with index `blockCount - 1`. The first 12 bytes refer to the initialization vector and the rest are the ciphertext.
+Entries in the private forest corresponding to externalized content blocks MUST have exactly one CID as their multi-value. This CID MUST refer to a ciphertext with exactly `12 + blockSize` bytes, except for the last block with index `blockCount - 1`. The first 12 bytes of the block MUST be an initialization vector, and the rest MUST be the ciphertext.
 
 If any externalized content blocks exceed the specified `blockSize` or are missing in the private forest despite having a lower index than `blockCount` during file read operations, then these operations MUST produce an error.
 

--- a/spec/private-wnfs.md
+++ b/spec/private-wnfs.md
@@ -296,7 +296,7 @@ To illustrate this mode, consider the following diagram. An agent may only have 
 
 `getShards : PrivateFile -> Array<Namefilter>`
 
-The blocks for [external content](#3211-externalized-content) with `key` and `count` MUST have namefilters of the form $\text{saturate}(\text{add}(\text{sha3}(\textsf{key} || \textsf{encode}(i), \textsf{bareName})))$, where 
+The blocks for [external content](#3211-externalized-content) with `key` and `count` MUST have namefilters of the form $\text{saturate}(\text{add}(\textsf{key}, \text{add}(\text{sha3}(\textsf{key} || \textsf{encode}(i), \textsf{bareName}))))$, where 
 - the block index $i$ MUST range from $0$ to $\textsf{blockCount} - 1$ inclusive.
 - $||$ denotes byte array concatenation
 - $\textsf{bareName}$ is the bare namefilter from the private file's header.

--- a/spec/private-wnfs.md
+++ b/spec/private-wnfs.md
@@ -74,7 +74,7 @@ A space optimization delaying the creation of additional layers until 3 collisio
 
 #### 2.1.1.3 `Entry`
 
-A leaf node, containing the expanded label as well as a value. As the private forest for WNFS, this MUST contain a namefilter as label and a set of CIDs of ciphertexts of conflicting writes as the value. This set of CIDs is also called the multi-value.
+A leaf node, containing the expanded label as well as a value. As the private forest for WNFS, this MUST contain a namefilter as label and a set of CIDs of ciphertexts of conflicting writes as the value.
 
 ## 2.2 Ciphertext Files
 


### PR DESCRIPTION
[:scroll: Preview](https://github.com/wnfs-wg/spec/blob/matheus23/file-sharding/spec/private-wnfs.md)

@expede: I don't know what the purpose of the skip ratchet was in private file sharding, so I'm proposing this way of sharding files without a skip ratchet in between.

Design goals were:
- every block has a limited size
- avoid having a metadata change in the PrivateFile header requiring a re-encrypt of any content blocks (having the file content encryption keys be derived from the header's skip ratchet would have meant that. So we avoid that by keeping another key around that is allowed to stay the same across revisions)
- you can seek efficiently in the file content (this is now O(1))
- make it possible to share access to only a file's content at a single revision without sharing access to all future revisions (to do this, just share the `key` and bare namefilter)

Design non-goals:
- efficient inserts/removes/in-place updates in the file content (The UnixFS file protocol supports that. In practice I don't know *anyone* making use of that. It's considerably harder to implement & provide interfaces for. Could be a future-future thing) 
- make it possible to share read access to only a file's content, while giving access to all revisions temporally (this *could* in theory be enabled by making `key` a skip ratchet instead of randomly-generated every revision. I don't think that's particularily useful though and may not be worth the complexity)

Work on #10 