### PR TITLE
Change enum variant signalling: Capsule Types

### DIFF
--- a/.github/workflows/words-to-ignore.txt
+++ b/.github/workflows/words-to-ignore.txt
@@ -99,6 +99,8 @@ preimage like image
 IND-CCA
 multivalue like value
 PKI
+pre-defined
+erroring
 
 # rationale
 Combinatoric

--- a/.github/workflows/words-to-ignore.txt
+++ b/.github/workflows/words-to-ignore.txt
@@ -103,6 +103,9 @@ PKI
 # rationale
 Combinatoric
 POS like ABC
+deserialize like serialize
+enum like structure
+javascript
 
 # other
 md

--- a/.github/workflows/words-to-ignore.txt
+++ b/.github/workflows/words-to-ignore.txt
@@ -104,6 +104,7 @@ PKI
 Combinatoric
 POS like ABC
 deserialize like serialize
+deserialization like serialization
 enum like structure
 javascript
 

--- a/rationale/encoding.md
+++ b/rationale/encoding.md
@@ -1,14 +1,14 @@
 This documents our reasoning for current choices of encoding and potential alternatives.
 
-# Enum Variant Signalling
+# Enum Variant Signaling
 
 ## Need
 
-In various places, WNFS data structures are allowed to point to different types of data, e.g. a directory entry may point to yet another directory or a file instead. Encoding a datum that allows a deserialization procedure to find out which deserialization subprocedure to use is usually called signalling.
+In various places, WNFS data structures are allowed to point to different types of data, e.g. a directory entry may point to yet another directory or a file instead. Encoding a datum that allows a deserialization procedure to find out which deserialization sub-procedure to use is usually called signaling.
 
 ## Choice
 
-Signalling works by wrapping the data DAG-CBOR with an object containing a single key like this:
+Signaling works by wrapping the data DAG-CBOR with an object containing a single key like this:
 
 ```typescript
 type Node = File | Dir
@@ -25,9 +25,9 @@ type Dir = {
 The key then indicates which variant you're supposed to decode at the value.
 
 Some advantages of doing this include:
-- In encodings like DAG-CBOR, when an object wraps some data, the object's key always precedes the data value in the encoded byte sequence. This means that a procedure can prepare the appropriate subprocedure to decode the value in advance.
-- It spares some bytes compared to alternatives: In DAG-CBOR, it only requires a single byte signalling the wrapping object, and additionally some bytes for the string identifier.
-- Using a string key as signalling allows adding future variants or even independently developed extensions with minimal chance that these extensions accidentally reuse the same signalling bytes for different data.
+- In encodings like DAG-CBOR, when an object wraps some data, the object's key always precedes the data value in the encoded byte sequence. This means that a procedure can prepare the appropriate sub-procedure to decode the value in advance.
+- It spares some bytes compared to alternatives: In DAG-CBOR, it only requires a single byte signaling the wrapping object, and additionally some bytes for the string identifier.
+- Using a string key as signaling allows adding future variants or even independently developed extensions with minimal chance that these extensions accidentally reuse the same signaling bytes for different data.
 
 ## Alternatives
 
@@ -49,6 +49,6 @@ type Dir = {
 }
 ```
 
-This seems natural to lots of developers and is used for signalling in lots of other places, however, it has some downsides:
+This seems natural to lots of developers and is used for signaling in lots of other places, however, it has some downsides:
 - When encoded as DAG-CBOR, the keys are sorted, thus the `type` key may not appear first, or even last. A deserialization procedure now has to cache the values of all other keys before it knows what special deserialization procedure to use. This is not memory or performance efficient.
-- Even though some programming languages such as javascript or python allow (and/or encourage) you to deserialize DAG-CBOR into dynamic objects that can be worked on directly, in other programming languages like rust, C++ or most statically type languages one usually doesn't work with dynamic objects and instead deserializes into memory-efficient data structures. Libraries like `serde` in rust can't efficiently support deserializing objects that use signalling like this, preventing performance techniques like zero-copy deserialization.
+- Even though some programming languages such as javascript or python allow (and/or encourage) you to deserialize DAG-CBOR into dynamic objects that can be worked on directly, in other programming languages like rust, C++ or most statically type languages one usually doesn't work with dynamic objects and instead deserializes into memory-efficient data structures. Libraries like `serde` in rust can't efficiently support deserializing objects that use signaling like this, preventing performance techniques like zero-copy deserialization.

--- a/rationale/encoding.md
+++ b/rationale/encoding.md
@@ -1,0 +1,54 @@
+This documents our reasoning for current choices of encoding and potential alternatives.
+
+# Enum Variant Signalling
+
+## Need
+
+In various places, WNFS data structures are allowed to point to different types of data, e.g. a directory entry may point to yet another directory or a file instead. Encoding a datum that allows a deserialization procedure to find out which deserialization subprocedure to use is usually called signalling.
+
+## Choice
+
+Signalling works by wrapping the data DAG-CBOR with an object containing a single key like this:
+
+```typescript
+type Node = File | Dir
+
+type File = {
+  "file": { /* ... */ }
+}
+
+type Dir = {
+  "dir": { /* ... */ }
+}
+```
+
+The key then indicates which variant you're supposed to decode at the value.
+
+Some advantages of doing this include:
+- In encodings like DAG-CBOR, when an object wraps some data, the object's key always precedes the data value in the encoded byte sequence. This means that a procedure can prepare the appropriate subprocedure to decode the value in advance.
+- It spares some bytes compared to alternatives: In DAG-CBOR, it only requires a single byte signalling the wrapping object, and additionally some bytes for the string identifier.
+- Using a string key as signalling allows adding future variants or even independently developed extensions with minimal chance that these extensions accidentally reuse the same signalling bytes for different data.
+
+## Alternatives
+
+### `type` key on object
+
+In previous versions of WNFS, we've encoded a string at a known key (`type`) in an object like this:
+
+```typescript
+type Node = File | Dir
+
+type File = {
+  type: "file"
+  // ...
+}
+
+type Dir = {
+  type: "dir"
+  // ...
+}
+```
+
+This seems natural to lots of developers and is used for signalling in lots of other places, however, it has some downsides:
+- When encoded as DAG-CBOR, the keys are sorted, thus the `type` key may not appear first, or even last. A deserialization procedure now has to cache the values of all other keys before it knows what special deserialization procedure to use. This is not memory or performance efficient.
+- Even though some programming languages such as javascript or python allow (and/or encourage) you to deserialize DAG-CBOR into dynamic objects that can be worked on directly, in other programming languages like rust, C++ or most statically type languages one usually doesn't work with dynamic objects and instead deserializes into memory-efficient data structures. Libraries like `serde` in rust can't efficiently support deserializing objects that use signalling like this, preventing performance techniques like zero-copy deserialization.

--- a/spec/private-wnfs.md
+++ b/spec/private-wnfs.md
@@ -124,14 +124,15 @@ type PrivateNode
   | PrivateFile
 
 type PrivateDirectory = {
-  type: "wnfs/priv/dir"
-  version: "0.2.0"
-  headerCid: Cid
-  previous: Array<PrivateBacklink>
+  "wnfs/priv/dir": {
+    version: "0.2.0"
+    headerCid: Cid
+    previous: Array<PrivateBacklink>
 
-  // USERLAND
-  metadata: Metadata
-  entries: Record<string, PrivateRef>
+    // USERLAND
+    metadata: Metadata
+    entries: Record<string, PrivateRef>
+  }
 }
 
 type PrivateRef = {
@@ -142,20 +143,27 @@ type PrivateRef = {
 }
 
 type PrivateFile = {
-  type: "wnfs/priv/file"
-  version: "0.2.0"
-  headerCid: Cid
-  previous: Array<PrivateBacklink>
+  "wnfs/priv/file": {
+    version: "0.2.0"
+    headerCid: Cid
+    previous: Array<PrivateBacklink>
 
-  // USERLAND
-  metadata: Metadata
-  content: ByteArray | ExternalContent
+    // USERLAND
+    metadata: Metadata
+    content: InlineContent | ExternalContent
+  }
+}
+
+type InlineContent = {
+  "inline": ByteArray
 }
 
 type ExternalContent = {
-  key: Key
-  blockSize: Uint64 // in bytes, at max 262132
-  blockCount: Uint64
+  "external": {
+    key: Key
+    blockSize: Uint64 // in bytes, at max 262,116
+    blockCount: Uint64
+  }
 }
 ```
 

--- a/spec/private-wnfs.md
+++ b/spec/private-wnfs.md
@@ -167,6 +167,8 @@ type ExternalContent = {
 }
 ```
 
+See the [validation specification](/spec/validation.md) on requirements for validating this data during deserialization.
+
 A file in the cleartext layer turns into a `PrivateNodeHeader` and `PrivateNode` in the cleartext data layer. Each of these data is then encrypted and put under the same label in the `PrivateForest` as a block of the encrypted data layer:
 
 ```typescript

--- a/spec/public-wnfs.md
+++ b/spec/public-wnfs.md
@@ -8,7 +8,7 @@ Nodes need to be encoded as dag-cbor.
 
 A directory node contains a map of entry names to either symlinks or CIDs that resolve to another directory or to a file.
 
-See the [`notation.md`](/spec/notation.md) for informatoin on the notation used and the [validation specification](/spec/validation.md) on details of verifying these data structures during deserialization.
+See the [`notation.md`](/spec/notation.md) for information on the notation used and the [validation specification](/spec/validation.md) on details of verifying these data structures during deserialization.
 
 ```typescript
 type PublicRoot = Cbor<PublicDirectory>

--- a/spec/public-wnfs.md
+++ b/spec/public-wnfs.md
@@ -8,6 +8,8 @@ Nodes need to be encoded as dag-cbor.
 
 A directory node contains a map of entry names to either symlinks or CIDs that resolve to another directory or to a file.
 
+See the [`notation.md`](/spec/notation.md) for informatoin on the notation used and the [validation specification](/spec/validation.md) on details of verifying these data structures during deserialization.
+
 ```typescript
 type PublicRoot = Cbor<PublicDirectory>
 

--- a/spec/public-wnfs.md
+++ b/spec/public-wnfs.md
@@ -16,12 +16,13 @@ type PublicNode
   | PublicFile
 
 type PublicDirectory = {
-  type: "wnfs/pub/dir"
-  version: "0.2.0"
-  previous: Array<Cid<Cbor<PublicDirectory>>>
-  // userland:
-  metadata: Metadata
-  entries: Record<string, Cid<Cbor<PublicNode>> | PublicSymlink>
+  "wnfs/pub/dir": {
+    version: "0.2.0"
+    previous: Array<Cid<Cbor<PublicDirectory>>>
+    // userland:
+    metadata: Metadata
+    entries: Record<string, Cid<Cbor<PublicNode>> | PublicSymlink>
+  }
 }
 
 type PublicSymlink = {
@@ -29,12 +30,13 @@ type PublicSymlink = {
 }
 
 type PublicFile = {
-  type: "wnfs/pub/file"
-  version: "0.2.0"
-  previous: Array<Cid<Cbor<PublicFile>>>
-  // userland:
-  metadata: Metadata
-  content: Cid<IPFSUnixFSFile>
+  "wnfs/pub/file": {
+    version: "0.2.0"
+    previous: Array<Cid<Cbor<PublicFile>>>
+    // userland:
+    metadata: Metadata
+    content: Cid<IPFSUnixFSFile>
+  }
 }
 ```
 

--- a/spec/shared-private-data.md
+++ b/spec/shared-private-data.md
@@ -78,7 +78,7 @@ Here `encode` is a function that maps a share counter to a low-endian byte array
 
 The `recipientExchangeKey` are the recipient device's exchange key bytes, including the protocol versioning prefix.
 
-## 3.2. Share Payload
+## 3.2 Share Payload
 
 The share payload MUST be a non-empty list of CIDs to [RSAES-OAEP](https://datatracker.ietf.org/doc/html/rfc3447#section-7.1)-encrypted ciphertexts.
 
@@ -88,25 +88,29 @@ The decrypted payload MUST be a CBOR-encoded object of following shape:
 type SharePayload = TemporalSharePointer | SnapshotSharePointer
 
 type TemporalSharePointer = {
-  type: "wnfs/share/temporal"
-  label: Hash<Namefilter> // 32 bytes SHA3 hash
-  cid: Cid // content block CID
-  temporalKey: Key // 32 bytes AES key
+  "wnfs/share/temporal": {
+    label: Hash<Namefilter> // 32 bytes SHA3 hash
+    cid: Cid // content block CID
+    temporalKey: Key // 32 bytes AES key
+  }
 }
 
 type SnapshotSharePointer = {
-  type: "wnfs/share/snapshot"
-  label: Hash<Namefilter> // 32 bytes SHA3 hash
-  cid: Cid // content block CID
-  snapshotKey: Key // 32 bytes AES key
+  "wnfs/share/snapshot": {
+    label: Hash<Namefilter> // 32 bytes SHA3 hash
+    cid: Cid // content block CID
+    snapshotKey: Key // 32 bytes AES key
+  }
 }
 ```
+
+See the [validation specification](/spec/validation.md) on requirements for validating this data during deserialization.
 
 Because v1 exchange keys are 2048 bit RSAES-OAEP keys, they can only encrypt up to 190 bits of data. Both payloads of the above format encode to 157, so fit within RSAES-OAEP limits.
 
 NB: Share payload *ciphertexts* will always be 256 bytes long, due to the way RSAES-OAEP works.
 
-### 3.2.2. Temporal Share Pointer
+### 3.2.2 Temporal Share Pointer
 
 The temporal share pointer consists of
 - a 32 byte private forest label used to look up the private node to decrypt in the private forest

--- a/spec/validation.md
+++ b/spec/validation.md
@@ -4,7 +4,7 @@ This document contains specifications on how implementations should validate inc
 
 The goals with these extra validation steps are:
 - Ensure consistency between different specification-adhering implementations. If two implementations parse the same data and are both spec-adherent, they should either show the same data to the user or at least one of them errors out.
-- Keep enough extensibility in the specification format for it to eventuall evolve independently from the spec.
+- Keep enough extensibility in the specification format for it to eventually evolve independently from the spec.
 
 
 ## Enum Variant Validation

--- a/spec/validation.md
+++ b/spec/validation.md
@@ -1,0 +1,44 @@
+# Notes on Validation
+
+This document contains specifications on how implementations should validate incoming WNFS data.
+
+The goals with these extra validation steps are:
+- Ensure consistency between different specification-adhering implementations. If two implementations parse the same data and are both spec-adherent, they should either show the same data to the user or at least one of them errors out.
+- Keep enough extensibility in the specification format for it to eventuall evolve independently from the spec.
+
+
+## Enum Variant Validation
+
+In WNFS data, enum variants are encoded via an object wrapper with a single key that identifies its variant, as in this simplified example:
+
+```typescript
+type Node = File | Dir
+
+type File = {
+  "file": {
+    // file data
+  }
+}
+
+type Dir = {
+  "dir": {
+    // dir data
+  }
+}
+```
+
+Reasons for preferring this format are described in [`rationale/encoding.md`](/rationale/encoding.md#enum-variant-signaling).
+
+After parsing an enum variant from an object an implementation MUST check that the wrapper object contains only a single entry and error out otherwise.
+If the variant identifier is unknown to the implementation, the implementation MUST error out.
+
+
+## Duplicate Object Keys
+
+The CBOR spec allows an object containing key-value pairs with the same key multiple times.
+This is disallowed by DAG-CBOR. WNFS implementations MUST error out if they detect a key being assigned twice in the same object.
+
+
+## Unexpected Object Keys
+
+Although one version of WNFS has a pre-defined schema, with a well-defined function determining whether a key in an object is expected or not, implementations MAY allow additional unexpected keys without erroring out.


### PR DESCRIPTION
This PR changes the way enum (sum type) variants are signalled.
Before:
```typescript
type Node = File | Dir

type File = {
  type: "file"
  // ...
}

type Dir = {
  type: "dir"
  // ...
}
```

After:
```typescript
type Node = File | Dir

type File = {
  "file": { /* ... */ }
}

type Dir = {
  "dir": { /* ... */ }
}
```

I added some [:scroll: rationale](https://github.com/wnfs-wg/spec/blob/matheus23/enum-variant-signalling/rationale/encoding.md#enum-variant-signalling) about that in this PR, too.

We noticed this would make our life in rs-wnfs with serde *much* easier, and it's probably also the alternative that allows faster & more memory-efficient decoders in principle.